### PR TITLE
Bugfix

### DIFF
--- a/src/validation.js
+++ b/src/validation.js
@@ -13,7 +13,7 @@ export function checkRules(rules: ValidationRules = {}, value: mixed) {
       const config = rules[rule];
       const options = (typeof config !== 'boolean') && config.options;
       const errorMessage = (typeof config !== 'boolean') ? config.errorMessage : GENERIC_ERROR_MESSAGE;
-      const result = validatorFn(value, options);
+      const result = options ? validatorFn(value, options) : validatorFn(value);
       if (!result) errors.push({ errorMessage, value });
       return result && acc;
     }, true);

--- a/tests/proxy-validator.js
+++ b/tests/proxy-validator.js
@@ -9,8 +9,9 @@ const validators = {
       },
       errorMessage: 'Minimum length 6 characters.'
     },
-    isUppercase: true
-  }
+    isUppercase: true,
+    isAlphanumeric: true,
+  },
 };
 
 const sanitizers = {


### PR DESCRIPTION
There are some validators that checks the arguments.length and perform some logic based on the number of params. Passing the options as 'undefined' will cause unexpected behavior. If there are no options, just pass one arg.